### PR TITLE
Add Nix Flake

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -1,0 +1,26 @@
+name: Update Flake Lockfile
+
+on:
+  schedule:
+    # run weekly at noon on sundays
+    - cron: "0 12 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-flake:
+    if: github.owner == 'galister'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@main
+        with:
+          pr-title: "Update flake.lock"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 .gdb_history
+result
+reuslt-*

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Resize screen: Same as Move screen but turn your controller to get the yellow la
 
 A Nix Flake is availabe as `github:galister/wlx-overlay-x`. Cached builds are available using [garnix](https://garnix.io/). See [garnix docs](https://garnix.io/docs/caching) to see how to utilize this binary cache.
 
+Run `nix flake show github:galister/wlx-overlay-x` to see all outputs of this flake.
+
 # Known Issues
 
 StereoKit fails to build with OpenXR version 1.0.29. You can downgrade your OpenXR syetem package to fix this.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Move screen: Grab using grip. Adjust distace using stick up/down while gripping.
 
 Resize screen: Same as Move screen but turn your controller to get the yellow laser.
 
+## Nix Flake
+
+A Nix Flake is availabe as `github:galister/wlx-overlay-x`. Cached builds are available using [garnix](https://garnix.io/). See [garnix docs](https://garnix.io/docs/caching) to see how to utilize this binary cache.
+
 # Known Issues
 
 StereoKit fails to build with OpenXR version 1.0.29. You can downgrade your OpenXR syetem package to fix this.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1693611461,
+        "narHash": "sha256-aPODl8vAgGQ0ZYFIRisxYG5MOGSkIczvu2Cd8Gb9+1Y=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "7f53fdb7bdc5bb237da7fefef12d099e4fd611ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1695360818,
+        "narHash": "sha256-JlkN3R/SSoMTa+CasbxS1gq+GpGxXQlNZRUh9+LIy/0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e35dcc04a3853da485a396bdd332217d0ac9054f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "A lightweight OpenXR overlay for Wayland desktops, inspired by XSOverlay";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+  };
+
+  outputs = inputs @ {
+    self,
+    flake-parts,
+    ...
+  }: let
+    version = builtins.substring 0 8 self.lastModifiedDate or "dirty";
+  in
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux" "aarch64-linux"];
+      perSystem = {
+        config,
+        pkgs,
+        ...
+      }: {
+        packages = {
+          default = config.packages.wlx-overlay-x;
+          wlx-overlay-x = pkgs.callPackage ./nix/derivation.nix {inherit self version;};
+        };
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,8 @@
           default = config.packages.wlx-overlay-x;
           wlx-overlay-x = pkgs.callPackage ./nix/derivation.nix {inherit self version;};
         };
+
+        formatter = pkgs.alejandra;
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -13,22 +13,9 @@
     self,
     flake-parts,
     ...
-  }: let
-    version = builtins.substring 0 8 self.lastModifiedDate or "dirty";
-  in
+  }:
     flake-parts.lib.mkFlake {inherit inputs;} {
       systems = ["x86_64-linux" "aarch64-linux"];
-      perSystem = {
-        config,
-        pkgs,
-        ...
-      }: {
-        packages = {
-          default = config.packages.wlx-overlay-x;
-          wlx-overlay-x = pkgs.callPackage ./nix/derivation.nix {inherit self version;};
-        };
-
-        formatter = pkgs.alejandra;
-      };
+      imports = [./nix/packages.nix ./nix/dev.nix];
     };
 }

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,0 +1,5 @@
+builds:
+  exclude: []
+  include:
+    - "checks.*.*"
+    - "packages.*.*"

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  rustPlatform,
+  alsa-lib,
+  cmake,
+  cpm-cmake,
+  fontconfig,
+  freetype,
+  libglvnd,
+  libxkbcommon,
+  mesa,
+  openxr-loader,
+  pipewire,
+  pkg-config,
+  wayland,
+  xorg,
+  # flake
+  self,
+  version,
+}:
+rustPlatform.buildRustPackage {
+  pname = "wlx-overlay-x";
+  inherit version;
+
+  src = lib.cleanSource self;
+
+  cargoLock = {
+    lockFile = ../Cargo.lock;
+    allowBuiltinFetchGit = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    alsa-lib
+    fontconfig
+    freetype
+    libglvnd
+    libxkbcommon
+    mesa
+    openxr-loader
+    pipewire
+    wayland
+    xorg.libX11
+  ];
+
+  # From https://github.com/StardustXR/server/blob/0dc5b1a92f5707efa16c251602935bdfc47ee7f0/nix/stardust-xr-server.nix
+  CPM_SOURCE_CACHE = "./build";
+  postPatch = ''
+    sk=$(echo $cargoDepsCopy/stereokit-sys-*/StereoKit)
+    mkdir -p $sk/build/cpm
+
+    # This is not ideal, the original approach was to fetch the exact cmake
+    # file version that was wanted from GitHub directly, but at least this way it comes from Nixpkgs.. so meh
+    cp ${cpm-cmake}/share/cpm/CPM.cmake $sk/build/cpm/CPM_0.32.2.cmake
+  '';
+
+  meta = with lib; {
+    description = "WlxOverlay for OpenXR, written in Rust";
+    homepage = "https://github.com/galister/wlx-overlay-x";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [Scrumplex];
+    mainProgram = "wlx-overlay-x";
+  };
+}

--- a/nix/dev.nix
+++ b/nix/dev.nix
@@ -1,0 +1,5 @@
+{
+  perSystem = {pkgs, ...}: {
+    formatter = pkgs.alejandra;
+  };
+}

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,0 +1,18 @@
+{self, ...}: let
+  version = builtins.substring 0 8 self.lastModifiedDate or "dirty";
+in {
+  perSystem = {
+    config,
+    pkgs,
+    ...
+  }: {
+    packages = {
+      default = config.packages.wlx-overlay-x;
+      wlx-overlay-x = pkgs.callPackage ./derivation.nix {inherit self version;};
+    };
+  };
+
+  flake.overlays.default = final: _: {
+    wlx-overlay-x = final.callPackage ./derivation.nix {inherit self version;};
+  };
+}


### PR DESCRIPTION
This should make it easier for people to install and/or run wlx-overlay-x on NixOS.

To allow binary builds for users, make sure to set up `garnix` on this repository. See https://garnix.io/ for details