### PR TITLE
Bugfix: Mouse move event is fired before launching "Mouse up" event

### DIFF
--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -70,11 +70,8 @@ impl InteractionHandler for ScreenInteractionHandler {
             }
         }
     }
-    fn on_pointer(&mut self, hit: &PointerHit, pressed: bool) {
+    fn on_pointer(&mut self, session: &AppSession, hit: &PointerHit, pressed: bool) {
         if let Ok(mut input) = INPUT.lock() {
-            let pos = self.mouse_transform.transform_point2(hit.uv);
-            input.mouse_move(pos);
-
             let btn = match hit.mode {
                 POINTER_SHIFT => MOUSE_RIGHT,
                 POINTER_ALT => MOUSE_MIDDLE,
@@ -82,10 +79,14 @@ impl InteractionHandler for ScreenInteractionHandler {
             };
 
             if pressed {
-                self.next_move = Instant::now() + Duration::from_millis(300);
+                self.next_move =
+                    Instant::now() + Duration::from_millis(session.click_freeze_time_ms);
             }
 
             input.send_button(btn, pressed);
+
+            let pos = self.mouse_transform.transform_point2(hit.uv);
+            input.mouse_move(pos);
         }
     }
     fn on_scroll(&mut self, _hit: &PointerHit, delta: f32) {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -6,7 +6,7 @@ use stereokit::{SkDraw, StereoKitMultiThread, Tex, TextureFormat, TextureType};
 use crate::{
     interactions::InteractionHandler,
     overlay::{OverlayBackend, OverlayRenderer, COLOR_TRANSPARENT},
-    AppState,
+    AppSession, AppState,
 };
 
 pub mod font;
@@ -232,7 +232,12 @@ impl<T1, T2> InteractionHandler for Canvas<T1, T2> {
             self.hover_controls[hit.hand] = None;
         }
     }
-    fn on_pointer(&mut self, hit: &crate::interactions::PointerHit, pressed: bool) {
+    fn on_pointer(
+        &mut self,
+        _session: &AppSession,
+        hit: &crate::interactions::PointerHit,
+        pressed: bool,
+    ) {
         let idx = if pressed {
             self.interactive_get_idx(hit.uv)
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,12 @@ pub struct AppState {
     session: AppSession,
 }
 
+impl AppState {
+    fn update_input(&mut self, sk: &SkDraw, interactables: &mut [OverlayData]) {
+        self.input.update(&self.session, sk, interactables);
+    }
+}
+
 fn main() {
     let sk = stereokit::Settings {
         app_name: "WlXrOverlay".to_string(),
@@ -187,7 +193,7 @@ fn main() {
 
     sk.run(
         |sk| {
-            app.input.update(sk, overlays.as_mut_slice());
+            app.update_input(sk, overlays.as_mut_slice());
 
             for overlay in overlays.iter_mut() {
                 if overlay.want_visible && !overlay.visible {

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -9,7 +9,7 @@ use stereokit::{
 
 use crate::{
     interactions::{DummyInteractionHandler, InteractionHandler},
-    AppState,
+    AppSession, AppState,
 };
 
 pub const COLOR_WHITE: Color128 = Color128 {
@@ -284,8 +284,13 @@ impl InteractionHandler for SplitOverlayBackend {
     fn on_scroll(&mut self, hit: &crate::interactions::PointerHit, delta: f32) {
         self.interaction.on_scroll(hit, delta);
     }
-    fn on_pointer(&mut self, hit: &crate::interactions::PointerHit, pressed: bool) {
-        self.interaction.on_pointer(hit, pressed);
+    fn on_pointer(
+        &mut self,
+        session: &AppSession,
+        hit: &crate::interactions::PointerHit,
+        pressed: bool,
+    ) {
+        self.interaction.on_pointer(session, hit, pressed);
     }
 }
 


### PR DESCRIPTION
This caused issues with pressing links, for example Discord channels. Before this fix, the user needed to have a very steady hand to not fire Drag event in the target application.

Mouse drag after 300ms freeze time still works properly.

Moved `input.mouse_move(...)` below `input.send_button(...)`

Added support for reading click_freeze_time_ms from AppSession